### PR TITLE
Have `./bin` directory in each `./versions/*` directory

### DIFF
--- a/libexec/kcenv-bin-path
+++ b/libexec/kcenv-bin-path
@@ -37,7 +37,7 @@ if [ "$KCENV_VERSION" = "system" ]; then
   fi
 fi
 
-KCENV_BIN_PATH="${KCENV_ROOT}/versions/${KCENV_VERSION}"
+KCENV_BIN_PATH="${KCENV_ROOT}/versions/${KCENV_VERSION}/bin"
 if [ ! -d "$KCENV_BIN_PATH" ]; then
   echo "kcenv: version \`${KCENV_VERSION}' is not installed" >&2
   exit 1

--- a/libexec/kcenv-install
+++ b/libexec/kcenv-install
@@ -18,7 +18,7 @@ else
   version="${1}"
 fi
 
-dst_path="${KCENV_ROOT}/versions/${version}"
+dst_path="${KCENV_ROOT}/versions/${version}/bin"
 if [ -f "${dst_path}/kubectl" ]; then
   echo "kubectl v${version} is already installed"
   exit 0

--- a/test/global.bats
+++ b/test/global.bats
@@ -17,7 +17,7 @@ load test_helper
 }
 
 @test "set KCENV_ROOT/version" {
-  mkdir -p "$KCENV_ROOT/versions/1.2.3"
+  mkdir -p "$KCENV_ROOT/versions/1.2.3/bin"
   run kcenv-global "1.2.3"
   assert_success
   run kcenv-global

--- a/test/local.bats
+++ b/test/local.bats
@@ -35,7 +35,7 @@ setup() {
 }
 
 @test "sets local version" {
-  mkdir -p "${KCENV_ROOT}/versions/1.2.3"
+  mkdir -p "${KCENV_ROOT}/versions/1.2.3/bin"
   run kcenv-local 1.2.3
   assert_success ""
   assert [ "$(cat .kubectl-version)" = "1.2.3" ]
@@ -43,7 +43,7 @@ setup() {
 
 @test "changes local version" {
   echo "1.0-pre" > .kubectl-version
-  mkdir -p "${KCENV_ROOT}/versions/1.2.3"
+  mkdir -p "${KCENV_ROOT}/versions/1.2.3/bin"
   run kcenv-local
   assert_success "1.0-pre"
   run kcenv-local 1.2.3

--- a/test/version-file-write.bats
+++ b/test/version-file-write.bats
@@ -22,7 +22,7 @@ setup() {
 }
 
 @test "writes value to arbitrary file" {
-  mkdir -p "${KCENV_ROOT}/versions/1.10.8"
+  mkdir -p "${KCENV_ROOT}/versions/1.10.8/bin"
   assert [ ! -e "my-version" ]
   run kcenv-version-file-write "${PWD}/my-version" "1.10.8"
   assert_success ""


### PR DESCRIPTION
For the future enhancements like to install more types of files

## Before

```
$ find versions -type f
versions/1.11.2/kubectl
versions/1.11.3/kubectl
versions/1.8.4/kubectl
versions/1.9.7/kubectl
```

## After

```
$ find versions -type f
versions/1.11.2/bin/kubectl
versions/1.11.3/bin/kubectl
versions/1.8.4/bin/kubectl
versions/1.9.7/bin/kubectl
```