### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+## [0.2.0] - 2018-09-16
+
+### Changed
+
+* Have `./bin` directory in each `./versions/*` directory [#1](https://github.com/yuya-takeyama/kcenv/pull/1)
+* `kcenv-exec` to require a command to run as the first argument [#2](https://github.com/yuya-takeyama/kcenv/pull/2)
+
+## [0.1.0] - 2018-09-15
+
+* Initial release

--- a/libexec/kcenv---version
+++ b/libexec/kcenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$KCENV_DEBUG" ] && set -x
 
-version="0.1.0"
+version="0.2.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q kcenv; then


### PR DESCRIPTION
## [0.2.0] - 2018-09-16

### Changed

* Have `./bin` directory in each `./versions/*` directory [#1](https://github.com/yuya-takeyama/kcenv/pull/1)
* `kcenv-exec` to require a command to run as the first argument [#2](https://github.com/yuya-takeyama/kcenv/pull/2)